### PR TITLE
Fix NMS export

### DIFF
--- a/mmdet/core/post_processing/bbox_nms.py
+++ b/mmdet/core/post_processing/bbox_nms.py
@@ -169,7 +169,8 @@ class GenericMulticlassNMS(Function):
         out_scores = reshape(
             g, g.op('Gather', multi_scores_flat, flat_score_indices, axis_i=0),
             [-1, 1])
-        class_indices = reshape(g, cast(class_indices, 'Float'), [-1, 1])
+        # Having either batch size or number of classes here equal to one is the limitation of implementation.
+        class_indices = reshape(g, cast(add(class_indices, batch_indices), 'Float'), [-1, 1])
 
         # Combine bboxes, scores and labels into a single tensor.
         # This a workaround for a PyTorch bug (feature?),


### PR DESCRIPTION
Currently NMS returns wrong class IDs for a case of class-dependent regression targets, as in Faster R-CNN's detection head, for example. The proposed change fixes this.

*Note*: This change assumes that detector's batch size is one. Making exported model correct for an arbitrary batch size is a separate task and I'm not sure that we need it for now,