### PR TITLE
Fix to avoid crash during NNCF import for CPU-only training

### DIFF
--- a/mmdet/integration/nncf/compression.py
+++ b/mmdet/integration/nncf/compression.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import torch
 from functools import partial
@@ -146,6 +147,8 @@ def wrap_nncf_model(model,
 
     model.dummy_forward_fn = dummy_forward
 
+    if 'log_dir' in nncf_config:
+        os.makedirs(nncf_config['log_dir'], exist_ok=True)
     compression_ctrl, model = create_compressed_model(model,
                                                       nncf_config,
                                                       dummy_forward_fn=dummy_forward,

--- a/mmdet/integration/nncf/utils.py
+++ b/mmdet/integration/nncf/utils.py
@@ -7,6 +7,13 @@ try:
     _is_nncf_enabled = True
 except ImportError:
     _is_nncf_enabled = False
+except RuntimeError as _e:
+    _is_nncf_enabled = False
+    print('Attention: RuntimeError happened when tried to import nncf')
+    print('           The reason may be in absent CUDA devices')
+    print('           RuntimeError:')
+    print('           ' + str(_e), flush=True)
+
 
 
 def is_nncf_enabled():


### PR DESCRIPTION
Also now training will create NNCF log dir if it is required.