### PR TITLE
Fix horizontal text detection for WEB OTE

### DIFF
--- a/mmdet/core/evaluation/text_evaluation.py
+++ b/mmdet/core/evaluation/text_evaluation.py
@@ -57,12 +57,11 @@ def polygon_from_points(points):
     return plg.Polygon(point_mat)
 
 
-def refactor_to_4_points(points):
-    """Return coordinates of 4 points of the each corner instead of 2 corner points"""
-    return [points[:2] +
-            [points[0]] + [points[1] + points[3]] +
-            [points[0] + points[2]] + [points[1] + points[3]] +
-            [points[0] + points[2]] + [points[1]]]
+def xywh_to_4_points(points):
+    """ Return coordinates of 4 points of the each corner instead of
+        x, y, width, height representation. """
+    x, y, w, h = points
+    return x, y, x, y + h, x + w, y + h, x + w, y
 
 
 def draw_gt_polygons(image, gt_polygons, gt_dont_care_nums):
@@ -199,8 +198,8 @@ def parse_gt_objects(gt_annotation, use_transcription):
     gt_dont_care_polygon_nums = []
 
     for gt_object in gt_annotation:
-        if len(gt_object['segmentation']) == 0:
-            polygon_coords = refactor_to_4_points(gt_object['bbox'])
+        if not gt_object['segmentation']:
+            polygon_coords = xywh_to_4_points(gt_object['bbox'])
         else:
             polygon_coords = gt_object['segmentation']
         polygon = polygon_from_points(polygon_coords)


### PR DESCRIPTION
During testing the WEB OTE tool I found the bug in Horizontal-text-detection related with different used ways to convert annotation from CVAT to json. I fixed this and tested on both cases: with annotations from WEB OTE and annotations got from the original tool to convert text datasets
1.	I added the function to convert BBox representation from 4 values to 4 corner points (8 values) to follow the logic of the text_evaluation script with polygons
2.	I covered the case if the `transcription` field was not provided at all
3.	I changed the way to iterate the ground-truth and predicted annotations to skip the images that were not annotated 
@Ilya-Krylov please look if it affects your changes for text-spotting
