### PR TITLE
Add CosineAnealingUntilEpoch hook

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -6,7 +6,7 @@ from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner, LoggerHook,
                          OptimizerHook, build_optimizer, load_checkpoint)
 
-from mmdet.core import (CosineAnealingLrLastEpochUpdaterHook, DistEvalHook,
+from mmdet.core import (CosineAnealingLrUntilEpochUpdaterHook, DistEvalHook,
                         DistEvalPlusBeforeRunHook, EvalHook,
                         EvalPlusBeforeRunHook, Fp16OptimizerHook)
 from mmdet.datasets import build_dataloader, build_dataset
@@ -139,9 +139,9 @@ def train_detector(model,
     else:
         optimizer_config = cfg.optimizer_config
 
-    if cfg['lr_config']['policy'] == 'CosineAnealingLastEpoch':
+    if cfg['lr_config']['policy'] == 'CosineAnealingUntilEpoch':
         cfg.lr_config.pop('policy')
-        lr_config = CosineAnealingLrLastEpochUpdaterHook(**cfg.lr_config)
+        lr_config = CosineAnealingLrUntilEpochUpdaterHook(**cfg.lr_config)
     else:
         lr_config = cfg.lr_config
 

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -6,7 +6,8 @@ from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner, LoggerHook,
                          OptimizerHook, build_optimizer, load_checkpoint)
 
-from mmdet.core import (DistEvalHook, DistEvalPlusBeforeRunHook, EvalHook,
+from mmdet.core import (CosineAnealingLrLastEpochUpdaterHook, DistEvalHook,
+                        DistEvalPlusBeforeRunHook, EvalHook,
                         EvalPlusBeforeRunHook, Fp16OptimizerHook)
 from mmdet.datasets import build_dataloader, build_dataset
 from mmdet.integration.nncf import CompressionHook, wrap_nncf_model
@@ -138,8 +139,14 @@ def train_detector(model,
     else:
         optimizer_config = cfg.optimizer_config
 
+    if cfg['lr_config']['policy'] == 'CosineAnealingLastEpoch':
+        cfg.lr_config.pop('policy')
+        lr_config = CosineAnealingLrLastEpochUpdaterHook(**cfg.lr_config)
+    else:
+        lr_config = cfg.lr_config
+
     # register hooks
-    runner.register_training_hooks(cfg.lr_config, optimizer_config,
+    runner.register_training_hooks(lr_config, optimizer_config,
                                    cfg.checkpoint_config, cfg.log_config,
                                    cfg.get('momentum_config', None))
     if distributed:

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -6,8 +6,7 @@ from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner, LoggerHook,
                          OptimizerHook, build_optimizer, load_checkpoint)
 
-from mmdet.core import (CosineAnealingLrUntilEpochUpdaterHook, DistEvalHook,
-                        DistEvalPlusBeforeRunHook, EvalHook,
+from mmdet.core import (DistEvalHook, DistEvalPlusBeforeRunHook, EvalHook,
                         EvalPlusBeforeRunHook, Fp16OptimizerHook)
 from mmdet.datasets import build_dataloader, build_dataset
 from mmdet.integration.nncf import CompressionHook, wrap_nncf_model
@@ -139,14 +138,8 @@ def train_detector(model,
     else:
         optimizer_config = cfg.optimizer_config
 
-    if cfg['lr_config']['policy'] == 'CosineAnealingUntilEpoch':
-        cfg.lr_config.pop('policy')
-        lr_config = CosineAnealingLrUntilEpochUpdaterHook(**cfg.lr_config)
-    else:
-        lr_config = cfg.lr_config
-
     # register hooks
-    runner.register_training_hooks(lr_config, optimizer_config,
+    runner.register_training_hooks(cfg.lr_config, optimizer_config,
                                    cfg.checkpoint_config, cfg.log_config,
                                    cfg.get('momentum_config', None))
     if distributed:

--- a/mmdet/core/utils/__init__.py
+++ b/mmdet/core/utils/__init__.py
@@ -1,8 +1,8 @@
 from .dist_utils import DistOptimizerHook, allreduce_grads
-from .lr_updater import CosineAnealingLrUntilEpochUpdaterHook
+from .lr_updater import CosineAnealingUntilEpochLrUpdaterHook
 from .misc import multi_apply, tensor2imgs, unmap
 
 __all__ = [
-    'allreduce_grads', 'CosineAnealingLrUntilEpochUpdaterHook', 'DistOptimizerHook',
+    'allreduce_grads', 'CosineAnealingUntilEpochLrUpdaterHook', 'DistOptimizerHook',
     'tensor2imgs', 'multi_apply', 'unmap'
 ]

--- a/mmdet/core/utils/__init__.py
+++ b/mmdet/core/utils/__init__.py
@@ -1,7 +1,8 @@
 from .dist_utils import DistOptimizerHook, allreduce_grads
+from .lr_updater import CosineAnealingLrLastEpochUpdaterHook
 from .misc import multi_apply, tensor2imgs, unmap
 
 __all__ = [
-    'allreduce_grads', 'DistOptimizerHook', 'tensor2imgs', 'multi_apply',
-    'unmap'
+    'allreduce_grads', 'CosineAnealingLrLastEpochUpdaterHook', 'DistOptimizerHook',
+    'tensor2imgs', 'multi_apply', 'unmap'
 ]

--- a/mmdet/core/utils/__init__.py
+++ b/mmdet/core/utils/__init__.py
@@ -1,8 +1,8 @@
 from .dist_utils import DistOptimizerHook, allreduce_grads
-from .lr_updater import CosineAnealingLrLastEpochUpdaterHook
+from .lr_updater import CosineAnealingLrUntilEpochUpdaterHook
 from .misc import multi_apply, tensor2imgs, unmap
 
 __all__ = [
-    'allreduce_grads', 'CosineAnealingLrLastEpochUpdaterHook', 'DistOptimizerHook',
+    'allreduce_grads', 'CosineAnealingLrUntilEpochUpdaterHook', 'DistOptimizerHook',
     'tensor2imgs', 'multi_apply', 'unmap'
 ]

--- a/mmdet/core/utils/lr_updater.py
+++ b/mmdet/core/utils/lr_updater.py
@@ -2,20 +2,20 @@ from mmcv.runner import HOOKS
 from mmcv.runner.hooks.lr_updater import CosineAnealingLrUpdaterHook, annealing_cos
 
 @HOOKS.register_module()
-class CosineAnealingLrLastEpochUpdaterHook(CosineAnealingLrUpdaterHook):
+class CosineAnealingLrUntilEpochUpdaterHook(CosineAnealingLrUpdaterHook):
     """The same LR updater as CosineAnealing but with `last epoch` support.
 
     Args:
         last_epoch (int, optional): The number of the last epoch where LR
             updating stops. This value can be greater than total_epochs. If it
-            is equal to -1 LR will update until the the end of the training.
+            is equal to -1 LR will update until the end of the training.
             Default: -1.
     """
 
     def __init__(self, last_epoch=-1, **kwargs):
         assert last_epoch != 0
         self.last_epoch = int(last_epoch)
-        super(CosineAnealingLrLastEpochUpdaterHook, self).__init__(**kwargs)
+        super(CosineAnealingLrUntilEpochUpdaterHook, self).__init__(**kwargs)
         if last_epoch > 0:
             assert self.by_epoch, '"last_epoch" requires "by_epoch" LR updating'
 

--- a/mmdet/core/utils/lr_updater.py
+++ b/mmdet/core/utils/lr_updater.py
@@ -1,0 +1,41 @@
+from mmcv.runner import HOOKS
+from mmcv.runner.hooks.lr_updater import CosineAnealingLrUpdaterHook, annealing_cos
+
+@HOOKS.register_module()
+class CosineAnealingLrLastEpochUpdaterHook(CosineAnealingLrUpdaterHook):
+    """The same LR updater as CosineAnealing but with `last epoch` support.
+
+    Args:
+        last_epoch (int, optional): The number of the last epoch where LR
+            updating stops. This value can be greater than total_epochs. If it
+            is equal to -1 LR will update until the the end of the training.
+            Default: -1.
+    """
+
+    def __init__(self, last_epoch=-1, **kwargs):
+        assert last_epoch != 0
+        if last_epoch > 0:
+            assert self.by_epoch, '"last_epoch" requires "by_epoch" LR updating'
+        self.last_epoch = int(last_epoch)
+        super(CosineAnealingLrLastEpochUpdaterHook, self).__init__(**kwargs)
+
+    def get_lr(self, runner, base_lr):
+        if self.last_epoch == -1:
+            self.last_epoch = runner.max_epochs
+
+        if self.by_epoch:
+            progress = runner.epoch
+            max_progress = self.last_epoch
+        else:
+            progress = runner.iter
+            max_progress = runner.max_iters
+
+        if self.min_lr_ratio is not None:
+            target_lr = base_lr * self.min_lr_ratio
+        else:
+            target_lr = self.min_lr
+
+        if self.by_epoch and self.last_epoch < progress:
+            return target_lr
+
+        return annealing_cos(base_lr, target_lr, progress / max_progress)

--- a/mmdet/core/utils/lr_updater.py
+++ b/mmdet/core/utils/lr_updater.py
@@ -3,6 +3,7 @@ from mmcv.runner.hooks.lr_updater import CosineAnealingLrUpdaterHook, annealing_
 
 @HOOKS.register_module()
 class CosineAnealingLrUntilEpochUpdaterHook(CosineAnealingLrUpdaterHook):
+    # TODO: Fix Anealing -> Annealing when the upgrade of MMCV will be possible
     """The same LR updater as CosineAnealing but with `last epoch` support.
 
     Args:

--- a/mmdet/core/utils/lr_updater.py
+++ b/mmdet/core/utils/lr_updater.py
@@ -14,10 +14,10 @@ class CosineAnealingLrLastEpochUpdaterHook(CosineAnealingLrUpdaterHook):
 
     def __init__(self, last_epoch=-1, **kwargs):
         assert last_epoch != 0
-        if last_epoch > 0:
-            assert self.by_epoch, '"last_epoch" requires "by_epoch" LR updating'
         self.last_epoch = int(last_epoch)
         super(CosineAnealingLrLastEpochUpdaterHook, self).__init__(**kwargs)
+        if last_epoch > 0:
+            assert self.by_epoch, '"last_epoch" requires "by_epoch" LR updating'
 
     def get_lr(self, runner, base_lr):
         if self.last_epoch == -1:

--- a/mmdet/core/utils/lr_updater.py
+++ b/mmdet/core/utils/lr_updater.py
@@ -2,7 +2,7 @@ from mmcv.runner import HOOKS
 from mmcv.runner.hooks.lr_updater import CosineAnealingLrUpdaterHook, annealing_cos
 
 @HOOKS.register_module()
-class CosineAnealingLrUntilEpochUpdaterHook(CosineAnealingLrUpdaterHook):
+class CosineAnealingUntilEpochLrUpdaterHook(CosineAnealingLrUpdaterHook):
     # TODO: Fix Anealing -> Annealing when the upgrade of MMCV will be possible
     """The same LR updater as CosineAnealing but with `last epoch` support.
 
@@ -16,7 +16,7 @@ class CosineAnealingLrUntilEpochUpdaterHook(CosineAnealingLrUpdaterHook):
     def __init__(self, last_epoch=-1, **kwargs):
         assert last_epoch != 0
         self.last_epoch = int(last_epoch)
-        super(CosineAnealingLrUntilEpochUpdaterHook, self).__init__(**kwargs)
+        super(CosineAnealingUntilEpochLrUpdaterHook, self).__init__(**kwargs)
         if last_epoch > 0:
             assert self.by_epoch, '"last_epoch" requires "by_epoch" LR updating'
 


### PR DESCRIPTION
Add a custom hook to support the standalone lr_config policy "CosineAnealingLastEpoch" which is alike "CosineAnealing" but with last_epoch parameter.  Didn't modify CosineAnealing for safety reasons. Last_epoch parameter allows to define the number of the last epoch where LR where updating stops.