### PR TITLE
Faster-RCNN performance fix

### DIFF
--- a/mmdet/ops/nms/nms_wrapper.py
+++ b/mmdet/ops/nms/nms_wrapper.py
@@ -96,7 +96,7 @@ def nms(boxes, scores, iou_threshold, score_thr=0.0, max_num=-1, offset=0):
         inds = order.masked_select(select)
     else:
         if max_num < 0:
-            max_num = boxes.size()[0] #sys.maxsize
+            max_num = boxes.size()[0]
         inds = NMSop.apply(boxes, scores, iou_threshold, score_thr, max_num, offset)
     dets = torch.cat((boxes[inds], scores[inds].reshape(-1, 1)), dim=1)
     if is_numpy:

--- a/mmdet/ops/nms/nms_wrapper.py
+++ b/mmdet/ops/nms/nms_wrapper.py
@@ -5,6 +5,8 @@ from torch.onnx import is_in_onnx_export
 
 from mmdet.integration.nncf import no_nncf_trace
 
+from mmcv.utils import deprecated_api_warning
+
 
 class NMSop(torch.autograd.Function):
     @staticmethod
@@ -23,6 +25,7 @@ class NMSop(torch.autograd.Function):
         return nms_symbolic_with_score_thr(g, bboxes, scores, iou_threshold, score_threshold, max_num, offset)
 
 
+@deprecated_api_warning({'iou_thr': 'iou_threshold'})
 def nms(boxes, scores, iou_threshold, score_thr=0.0, max_num=-1, offset=0):
     """Dispatch to either CPU or GPU NMS implementations.
 
@@ -93,7 +96,7 @@ def nms(boxes, scores, iou_threshold, score_thr=0.0, max_num=-1, offset=0):
         inds = order.masked_select(select)
     else:
         if max_num < 0:
-            max_num = sys.maxsize
+            max_num = boxes.size()[0] #sys.maxsize
         inds = NMSop.apply(boxes, scores, iou_threshold, score_thr, max_num, offset)
     dets = torch.cat((boxes[inds], scores[inds].reshape(-1, 1)), dim=1)
     if is_numpy:

--- a/mmdet/ops/nms/nms_wrapper.py
+++ b/mmdet/ops/nms/nms_wrapper.py
@@ -96,7 +96,7 @@ def nms(boxes, scores, iou_threshold, score_thr=0.0, max_num=-1, offset=0):
         inds = order.masked_select(select)
     else:
         if max_num < 0:
-            max_num = boxes.size()[0]
+            max_num = boxes.shape[0]
         inds = NMSop.apply(boxes, scores, iou_threshold, score_thr, max_num, offset)
     dets = torch.cat((boxes[inds], scores[inds].reshape(-1, 1)), dim=1)
     if is_numpy:

--- a/mmdet/utils/deployment/symbolic.py
+++ b/mmdet/utils/deployment/symbolic.py
@@ -299,9 +299,9 @@ def nms_symbolic_with_score_thr(g, bboxes, scores, iou_threshold, score_threshol
         from torch.onnx.symbolic_opset9 import select, squeeze, unsqueeze
         boxes = unsqueeze(g, bboxes, 0)
         scores = unsqueeze(g, unsqueeze(g, scores, 0), 0)
-        max_output_per_class = g.op(
-            'Constant',
-            value_t=torch.tensor([max_num], dtype=torch.long))
+        if not sym_help._is_value(max_num):
+            max_num = g.op("Constant", value_t=torch.tensor(max_num, dtype=torch.long))
+        max_output_per_class = max_num
         iou_threshold = g.op(
             'Constant',
             value_t=torch.tensor([iou_threshold], dtype=torch.float))

--- a/mmdet/utils/deployment/symbolic.py
+++ b/mmdet/utils/deployment/symbolic.py
@@ -300,7 +300,7 @@ def nms_symbolic_with_score_thr(g, bboxes, scores, iou_threshold, score_threshol
         boxes = unsqueeze(g, bboxes, 0)
         scores = unsqueeze(g, unsqueeze(g, scores, 0), 0)
         if not sym_help._is_value(max_num):
-            max_num = g.op("Constant", value_t=torch.tensor(max_num, dtype=torch.long))
+            max_num = g.op('Constant', value_t=torch.tensor(max_num, dtype=torch.long))
         max_output_per_class = max_num
         iou_threshold = g.op(
             'Constant',

--- a/mmdet/utils/deployment/symbolic.py
+++ b/mmdet/utils/deployment/symbolic.py
@@ -274,9 +274,9 @@ def patch_nms_aten_to():
         from mmdet.ops.nms import NMSop
         original_forward = NMSop.forward
 
-        def forward(ctx, bboxes, scores, iou_threshold, offset, score_threshold, max_num):
+        def forward(ctx, bboxes, scores, iou_threshold, score_threshold, max_num, offset):
             with torch.jit._disable_tracing():
-                inds = original_forward(ctx, bboxes, scores, iou_threshold, offset, score_threshold, max_num)
+                inds = original_forward(ctx, bboxes, scores, iou_threshold, score_threshold, max_num, offset)
             return inds
         NMSop.forward = staticmethod(forward)
 


### PR DESCRIPTION
Changed the `max_num` value from `sys.maxsize` to the number of boxes in the NMS input.
To solve problems with a possible changing in this value when reshaping the model, it was added as an additional input for the NMS.

Results of local performance measurements with using benchmark_app:
|  | Before | After |
| --- |:---:| :---:|
| Count (iterations) | 6 | 170 |
| Duration (ms) | 72126 | 60134 |
| Latency (ms) | 12415 | 351 |
| Throughput (FPS) | 0.08 | 2.84 |
