### PR TITLE
Add model stats to templates

### DIFF
--- a/configs/ote/custom-object-detection/gen3_mobilenetV2_ATSS/template.yaml
+++ b/configs/ote/custom-object-detection/gen3_mobilenetV2_ATSS/template.yaml
@@ -42,3 +42,7 @@ max_nodes: 1
 training_targets:
   - GPU
   - CPU
+
+# Stats.
+gigaflops: 20.6
+size: 9.1

--- a/configs/ote/custom-object-detection/gen3_mobilenetV2_SSD/template.yaml
+++ b/configs/ote/custom-object-detection/gen3_mobilenetV2_SSD/template.yaml
@@ -42,3 +42,7 @@ max_nodes: 1
 training_targets:
   - GPU
   - CPU
+
+# Stats.
+gigaflops: 9.4
+size: 7.6

--- a/configs/ote/custom-object-detection/gen3_resnet50_VFNet/template.yaml
+++ b/configs/ote/custom-object-detection/gen3_resnet50_VFNet/template.yaml
@@ -41,3 +41,7 @@ hyper_parameters:
 max_nodes: 1
 training_targets:
   - GPU
+
+# Stats.
+gigaflops: 457.4
+size: 126.0


### PR DESCRIPTION
All statistics were collected on the OpenVINO IR files obtained for corresponding model templates given 80 COCO classes.

GFLOPs were estimated with Model Analyzer (tag 2021.4.1) with a couple of bells and whistles. Opened a bug for correct FLOPs estimation for Deformable Convolution.

Model size was estimated with `ls -lh` command over the IR .bin file.

Build 441 ⏲️ 