### PR TITLE
Fix LR value after resuming training with ReduceOnPlateau optimizer

### DIFF
--- a/mmdet/apis/ote/extension/utils/hooks.py
+++ b/mmdet/apis/ote/extension/utils/hooks.py
@@ -482,6 +482,8 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
     def before_run(self, runner):
         # TODO: remove overloaded method after fixing the issue
         #  https://github.com/open-mmlab/mmdetection/issues/6572
+        for group in runner.optimizer.param_groups:
+            group.setdefault('initial_lr', group['lr'])
         self.base_lr = [
             group['lr'] for group in runner.optimizer.param_groups
         ]

--- a/mmdet/apis/ote/extension/utils/hooks.py
+++ b/mmdet/apis/ote/extension/utils/hooks.py
@@ -478,3 +478,10 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
                 logger=runner.logger)
             self.current_lr = max(self.current_lr * self.factor, self.min_lr)
         return self.current_lr
+
+    def before_run(self, runner):
+        # TODO: remove overloaded method after fixing the issue
+        #  https://github.com/open-mmlab/mmdetection/issues/6572
+        self.base_lr = [
+            group['lr'] for group in runner.optimizer.param_groups
+        ]

--- a/tests/test_ote_api.py
+++ b/tests/test_ote_api.py
@@ -410,8 +410,7 @@ class API(unittest.TestCase):
         self.assertEqual(output_model.model_status, ModelStatus.SUCCESS)
         modelinfo = torch.load(io.BytesIO(output_model.get_data("weights.pth")))
         if 'anchors' not in modelinfo.keys():
-            self.assertEqual(list(modelinfo.keys()), ['model', 'config', 'labels', 'confidence_threshold', 'VERSION'])
-        self.assertTrue('ellipse' in modelinfo['labels'])
+            self.assertEqual(list(modelinfo.keys()), ['model', 'config', 'label_schema', 'confidence_threshold', 'VERSION'])
 
         # Run inference.
         validation_performance = self.eval(task, output_model, val_dataset)

--- a/tests/test_ote_api.py
+++ b/tests/test_ote_api.py
@@ -409,8 +409,8 @@ class API(unittest.TestCase):
         # Test that output model is valid.
         self.assertEqual(output_model.model_status, ModelStatus.SUCCESS)
         modelinfo = torch.load(io.BytesIO(output_model.get_data("weights.pth")))
-        if 'anchors' not in modelinfo.keys():
-            self.assertEqual(list(modelinfo.keys()), ['model', 'config', 'label_schema', 'confidence_threshold', 'VERSION'])
+        modelinfo.pop('anchors', None)
+        self.assertEqual(list(modelinfo.keys()), ['model', 'config', 'label_schema', 'confidence_threshold', 'VERSION'])
 
         # Run inference.
         validation_performance = self.eval(task, output_model, val_dataset)


### PR DESCRIPTION
## Description
The temporary fix for the problem, when LR after training resuming is being restored to the initial value. 
It will be reverted, when this problem will be fixed on the mmcv side, as open-mmlab has a similar [issue](https://github.com/open-mmlab/mmdetection/issues/6572).

## Build
643