### PR TITLE
Data type for score in update_progress_callback is converted to float.

### DIFF
--- a/mmdet/apis/ote/apis/detection/ote_utils.py
+++ b/mmdet/apis/ote/apis/detection/ote_utils.py
@@ -106,22 +106,17 @@ class TrainingProgressCallback(TimeMonitorCallback):
 
     def on_epoch_end(self, epoch, logs=None):
         self.past_epoch_duration.append(time.time() - self.start_epoch_time)
-        self.__calculate_average_epoch()
+        self._calculate_average_epoch()
         score = None
         if hasattr(self.update_progress_callback, 'metric') and isinstance(logs, dict):
             score = logs.get(self.update_progress_callback.metric, None)
+            if isinstance(score, int):
+                score = float(score)
         # Workaround for NNCF trainer, which uses callback of a different type.
         if score is not None:
             self.update_progress_callback(self.get_progress(), score=score)
         else:
             self.update_progress_callback(int(self.get_progress()))
-
-    def __calculate_average_epoch(self):
-        if len(self.past_epoch_duration) > self.epoch_history:
-            del self.past_epoch_duration[0]
-        self.average_epoch = sum(self.past_epoch_duration) / len(
-            self.past_epoch_duration
-        )
 
 
 class InferenceProgressCallback(TimeMonitorCallback):

--- a/mmdet/apis/ote/apis/detection/ote_utils.py
+++ b/mmdet/apis/ote/apis/detection/ote_utils.py
@@ -110,11 +110,9 @@ class TrainingProgressCallback(TimeMonitorCallback):
         score = None
         if hasattr(self.update_progress_callback, 'metric') and isinstance(logs, dict):
             score = logs.get(self.update_progress_callback.metric, None)
-            if isinstance(score, int):
-                score = float(score)
         # Workaround for NNCF trainer, which uses callback of a different type.
         if score is not None:
-            self.update_progress_callback(self.get_progress(), score=score)
+            self.update_progress_callback(self.get_progress(), score=float(score))
         else:
             self.update_progress_callback(int(self.get_progress()))
 


### PR DESCRIPTION
1. Data type for score in update_progress_callback is declared as float, and this PR converts data type for score to float.

2. Unnecessary function __calculate_average_epoch() is removed, and it is replaced with _calculate_average_epoch() in ote_sdk.