### PR TITLE
Updates Shapely version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -91,7 +91,7 @@ scikit-image==0.17.2
 scikit-learn==0.24.2
 scipy==1.5.4
 sentencepiece==0.1.96
-Shapely==1.7.1
+Shapely==1.8.0
 six==1.15.0
 sklearn==0.0
 sty==1.0.0b12

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -14,5 +14,5 @@ tqdm
 onnx>=1.7.0
 onnxoptimizer
 onnxruntime>=1.1.2
-Shapely==1.7.1
+Shapely==1.8.0
 editdistance


### PR DESCRIPTION
Updates Shapely version from 1.7.1 to 1.8.0 (CVS-76761).
Tested in [PR#878](https://github.com/openvinotoolkit/training_extensions/pull/878) and BMM ([build 24699](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/24699/)).