### PR TITLE
Reword using of third party repositories

### DIFF
--- a/mmdet/core/bbox/assigners/atss_assigner.py
+++ b/mmdet/core/bbox/assigners/atss_assigner.py
@@ -35,6 +35,7 @@ class ATSSAssigner(BaseAssigner):
         self.iou_calculator = build_iou_calculator(iou_calculator)
         self.ignore_iof_thr = ignore_iof_thr
 
+    # The code from the following github repo was used as an example:
     # https://github.com/sfzhang15/ATSS/blob/master/atss_core/modeling/rpn/atss/loss.py
 
     def assign(self,

--- a/mmdet/datasets/cityscapes.py
+++ b/mmdet/datasets/cityscapes.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Modified from https://github.com/facebookresearch/detectron2/blob/master/detectron2/data/datasets/cityscapes.py # noqa
-# Uses code https://github.com/mcordts/cityscapesScripts/blob/master/cityscapesscripts/evaluation/evalInstanceLevelSemanticLabeling.py # noqa
+# Uses https://github.com/mcordts/cityscapesScripts/blob/master/cityscapesscripts/evaluation/evalInstanceLevelSemanticLabeling.py # noqa
 
 import glob
 import os

--- a/mmdet/datasets/pipelines/instaboost.py
+++ b/mmdet/datasets/pipelines/instaboost.py
@@ -9,7 +9,9 @@ class InstaBoost(object):
     Segmentation Via Probability Map Guided Copy-Pasting
     <https://arxiv.org/abs/1908.07801>`_.
 
-    Refer to https://github.com/GothicAi/Instaboost for implementation details.
+    The code from the following github repo was used as an example:
+    https://github.com/GothicAi/Instaboost
+    See it for implementation details.
     """
 
     def __init__(self,

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -1179,7 +1179,7 @@ class MinIoURandomCrop(object):
 class Corrupt(object):
     """Corruption augmentation.
 
-    Corruption transforms implemented based on
+    The code from the following github repo was used as an example:
     `imagecorruptions <https://github.com/bethgelab/imagecorruptions>`_.
 
     Args:

--- a/mmdet/models/dense_heads/fcos_head.py
+++ b/mmdet/models/dense_heads/fcos_head.py
@@ -27,8 +27,10 @@ class FCOSHead(AnchorFreeHead):
     low-quality predictions.
     Here norm_on_bbox, centerness_on_reg, dcn_on_last_conv are training
     tricks used in official repo, which will bring remarkable mAP gains
-    of up to 4.9. Please see https://github.com/tianzhi0549/FCOS for
-    more detail.
+    of up to 4.9.
+    The code from the following github repo was used as an example:
+    https://github.com/tianzhi0549/FCOS
+    -- see it for more detail.
 
     Args:
         num_classes (int): Number of categories excluding the background

--- a/mmdet/models/dense_heads/paa_head.py
+++ b/mmdet/models/dense_heads/paa_head.py
@@ -46,7 +46,8 @@ class PAAHead(ATSSHead):
     """Head of PAAAssignment: Probabilistic Anchor Assignment with IoU
     Prediction for Object Detection.
 
-    Code is modified from the `official github repo
+    The code from the following github repo was used as an example:
+    `official github repo
     <https://github.com/kkhoot/PAA/blob/master/paa_core
     /modeling/rpn/paa/loss.py>`_.
 

--- a/mmdet/models/losses/iou_loss.py
+++ b/mmdet/models/losses/iou_loss.py
@@ -116,7 +116,8 @@ def diou_loss(pred, target, eps=1e-7):
     r"""`Implementation of Distance-IoU Loss: Faster and Better
     Learning for Bounding Box Regression, https://arxiv.org/abs/1911.08287`_.
 
-    Code is modified from https://github.com/Zzh-tju/DIoU.
+    The code from the following github repo was used as an example:
+    https://github.com/Zzh-tju/DIoU.
 
     Args:
         pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),
@@ -171,7 +172,8 @@ def ciou_loss(pred, target, eps=1e-7):
     Model Learning and Inference for Object Detection and Instance
     Segmentation <https://arxiv.org/abs/2005.03572>`_.
 
-    Code is modified from https://github.com/Zzh-tju/CIoU.
+    The code from the following github repo was used as an example:
+    https://github.com/Zzh-tju/CIoU.
 
     Args:
         pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),


### PR DESCRIPTION
Use the proper wording in the places where there was no copy of code
found.